### PR TITLE
fix: IRD-1629 fix java version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '17.0.7+7'
         java-package: jre
 
     - name: Copy workspaces lock file to subfolders


### PR DESCRIPTION
The issue seems to be related to the latest Java version having changes with the JRE and JDK. Since there is no need to compile any new code, the JDK is not required, however the latest version requires both JRE and JDK. The solution is to fix to the last known 17.x.x version that worked fine with just the JRE.